### PR TITLE
Standardize the format of the base keyword in domain types

### DIFF
--- a/section-03/end/DomeGym.Domain/Gym.cs
+++ b/section-03/end/DomeGym.Domain/Gym.cs
@@ -11,9 +11,9 @@ public class Gym
     public Guid Id { get; }
 
     public Gym(
-    int maxRooms,
-    Guid subscriptionId,
-    Guid? id = null)
+        int maxRooms,
+        Guid subscriptionId,
+        Guid? id = null)
     {
         _maxRooms = maxRooms;
         _subscriptionId = subscriptionId;

--- a/section-04/end/DomeGym.Domain/AdminAggregate/Admin.cs
+++ b/section-04/end/DomeGym.Domain/AdminAggregate/Admin.cs
@@ -10,8 +10,7 @@ public class Admin : AggregateRoot
     public Admin(
         Guid userId,
         Guid subscriptionId,
-        Guid? id = null)
-        : base(id ?? Guid.NewGuid())
+        Guid? id = null) : base(id ?? Guid.NewGuid())
     {
         _userId = userId;
         _subscriptionId = subscriptionId;

--- a/section-04/end/DomeGym.Domain/Common/Entities/Schedule.cs
+++ b/section-04/end/DomeGym.Domain/Common/Entities/Schedule.cs
@@ -9,8 +9,7 @@ public class Schedule : Entity
 
     public Schedule(
         Dictionary<DateOnly, List<TimeRange>>? calendar = null,
-        Guid? id = null)
-            : base(id ?? Guid.NewGuid())
+        Guid? id = null) : base(id ?? Guid.NewGuid())
     {
         _calendar = calendar ?? new();
     }

--- a/section-04/end/DomeGym.Domain/GymAggregate/Gym.cs
+++ b/section-04/end/DomeGym.Domain/GymAggregate/Gym.cs
@@ -11,10 +11,9 @@ public class Gym : AggregateRoot
     private readonly List<Guid> _roomIds = new();
 
     public Gym(
-    int maxRooms,
-    Guid subscriptionId,
-    Guid? id = null)
-        : base(id ?? Guid.NewGuid())
+        int maxRooms,
+        Guid subscriptionId,
+        Guid? id = null) : base(id ?? Guid.NewGuid())
     {
         _maxRooms = maxRooms;
         _subscriptionId = subscriptionId;

--- a/section-04/end/DomeGym.Domain/RoomAggregate/Room.cs
+++ b/section-04/end/DomeGym.Domain/RoomAggregate/Room.cs
@@ -16,8 +16,7 @@ public class Room : AggregateRoot
         int maxDailySessions,
         Guid gymId,
         Schedule? schedule = null,
-        Guid? id = null)
-            : base(id ?? Guid.NewGuid())
+        Guid? id = null) : base(id ?? Guid.NewGuid())
     {
         _maxDailySessions = maxDailySessions;
         _gymId = gymId;

--- a/section-04/end/DomeGym.Domain/SessionAggregate/Session.cs
+++ b/section-04/end/DomeGym.Domain/SessionAggregate/Session.cs
@@ -21,8 +21,7 @@ public class Session : AggregateRoot
         TimeRange time,
         int maxParticipants,
         Guid trainerId,
-        Guid? id = null)
-            : base(id ?? Guid.NewGuid())
+        Guid? id = null) : base(id ?? Guid.NewGuid())
     {
         Date = date;
         Time = time;

--- a/section-04/end/DomeGym.Domain/SubscriptionAggregate/Subscription.cs
+++ b/section-04/end/DomeGym.Domain/SubscriptionAggregate/Subscription.cs
@@ -14,8 +14,7 @@ public class Subscription : AggregateRoot
     public Subscription(
         SubscriptionType subscriptionType,
         Guid adminId,
-        Guid? id = null)
-            : base(id ?? Guid.NewGuid())
+        Guid? id = null) : base(id ?? Guid.NewGuid())
     {
         _subscriptionType = subscriptionType;
         _maxGyms = GetMaxGyms();

--- a/section-04/end/DomeGym.Domain/TrainerAggregate/Trainer.cs
+++ b/section-04/end/DomeGym.Domain/TrainerAggregate/Trainer.cs
@@ -14,8 +14,7 @@ public class Trainer : AggregateRoot
     public Trainer(
         Guid userId,
         Schedule? schedule = null,
-        Guid? id = null)
-            : base(id ?? Guid.NewGuid())
+        Guid? id = null) : base(id ?? Guid.NewGuid())
     {
         _userId = userId;
         _schedule = schedule ?? Schedule.Empty();

--- a/section-04/start/DomeGym.Domain/Gym.cs
+++ b/section-04/start/DomeGym.Domain/Gym.cs
@@ -11,9 +11,9 @@ public class Gym
     public Guid Id { get; }
 
     public Gym(
-    int maxRooms,
-    Guid subscriptionId,
-    Guid? id = null)
+        int maxRooms,
+        Guid subscriptionId,
+        Guid? id = null)
     {
         _maxRooms = maxRooms;
         _subscriptionId = subscriptionId;

--- a/section-05/end/src/DomeGym.Domain/AdminAggregate/Admin.cs
+++ b/section-05/end/src/DomeGym.Domain/AdminAggregate/Admin.cs
@@ -14,8 +14,7 @@ public class Admin : AggregateRoot
     public Admin(
         Guid userId,
         Guid? subscriptionId = null,
-        Guid? id = null)
-        : base(id ?? Guid.NewGuid())
+        Guid? id = null) : base(id ?? Guid.NewGuid())
     {
         UserId = userId;
         SubscriptionId = subscriptionId;

--- a/section-05/end/src/DomeGym.Domain/Common/Entities/Schedule.cs
+++ b/section-05/end/src/DomeGym.Domain/Common/Entities/Schedule.cs
@@ -10,8 +10,7 @@ public class Schedule : Entity
 
     public Schedule(
         Dictionary<DateOnly, List<TimeRange>>? calendar = null,
-        Guid? id = null)
-            : base(id ?? Guid.NewGuid())
+        Guid? id = null) : base(id ?? Guid.NewGuid())
     {
         _calendar = calendar ?? new();
     }

--- a/section-05/end/src/DomeGym.Domain/GymAggregate/Gym.cs
+++ b/section-05/end/src/DomeGym.Domain/GymAggregate/Gym.cs
@@ -22,8 +22,7 @@ public class Gym : AggregateRoot
         string name,
         int maxRooms,
         Guid subscriptionId,
-        Guid? id = null)
-            : base(id ?? Guid.NewGuid())
+        Guid? id = null) : base(id ?? Guid.NewGuid())
     {
         Name = name;
         _maxRooms = maxRooms;

--- a/section-05/end/src/DomeGym.Domain/SessionAggregate/Session.cs
+++ b/section-05/end/src/DomeGym.Domain/SessionAggregate/Session.cs
@@ -39,8 +39,7 @@ public class Session : AggregateRoot
         DateOnly date,
         TimeRange time,
         List<SessionCategory> categories,
-        Guid? id = null)
-            : base(id ?? Guid.NewGuid())
+        Guid? id = null) : base(id ?? Guid.NewGuid())
     {
         Name = name;
         Description = description;

--- a/section-05/end/src/DomeGym.Domain/SubscriptionAggregate/Subscription.cs
+++ b/section-05/end/src/DomeGym.Domain/SubscriptionAggregate/Subscription.cs
@@ -16,8 +16,7 @@ public class Subscription : AggregateRoot
     public Subscription(
         SubscriptionType subscriptionType,
         Guid adminId,
-        Guid? id = null)
-            : base(id ?? Guid.NewGuid())
+        Guid? id = null) : base(id ?? Guid.NewGuid())
     {
         SubscriptionType = subscriptionType;
         _maxGyms = GetMaxGyms();

--- a/section-05/end/src/DomeGym.Domain/TrainerAggregate/Trainer.cs
+++ b/section-05/end/src/DomeGym.Domain/TrainerAggregate/Trainer.cs
@@ -17,8 +17,7 @@ public class Trainer : AggregateRoot
     public Trainer(
         Guid userId,
         Schedule? schedule = null,
-        Guid? id = null)
-            : base(id ?? Guid.NewGuid())
+        Guid? id = null) : base(id ?? Guid.NewGuid())
     {
         UserId = userId;
         _schedule = schedule ?? Schedule.Empty();

--- a/section-05/start/src/DomeGym.Domain/AdminAggregate/Admin.cs
+++ b/section-05/start/src/DomeGym.Domain/AdminAggregate/Admin.cs
@@ -13,8 +13,7 @@ public class Admin : AggregateRoot
     public Admin(
         Guid userId,
         Guid? subscriptionId = null,
-        Guid? id = null)
-        : base(id ?? Guid.NewGuid())
+        Guid? id = null) : base(id ?? Guid.NewGuid())
     {
         UserId = userId;
         SubscriptionId = subscriptionId;

--- a/section-05/start/src/DomeGym.Domain/Common/Entities/Schedule.cs
+++ b/section-05/start/src/DomeGym.Domain/Common/Entities/Schedule.cs
@@ -10,8 +10,7 @@ public class Schedule : Entity
 
     public Schedule(
         Dictionary<DateOnly, List<TimeRange>>? calendar = null,
-        Guid? id = null)
-            : base(id ?? Guid.NewGuid())
+        Guid? id = null) : base(id ?? Guid.NewGuid())
     {
         _calendar = calendar ?? new();
     }

--- a/section-05/start/src/DomeGym.Domain/GymAggregate/Gym.cs
+++ b/section-05/start/src/DomeGym.Domain/GymAggregate/Gym.cs
@@ -22,8 +22,7 @@ public class Gym : AggregateRoot
         string name,
         int maxRooms,
         Guid subscriptionId,
-        Guid? id = null)
-            : base(id ?? Guid.NewGuid())
+        Guid? id = null) : base(id ?? Guid.NewGuid())
     {
         Name = name;
         _maxRooms = maxRooms;

--- a/section-05/start/src/DomeGym.Domain/SessionAggregate/Session.cs
+++ b/section-05/start/src/DomeGym.Domain/SessionAggregate/Session.cs
@@ -39,8 +39,7 @@ public class Session : AggregateRoot
         DateOnly date,
         TimeRange time,
         List<SessionCategory> categories,
-        Guid? id = null)
-            : base(id ?? Guid.NewGuid())
+        Guid? id = null) : base(id ?? Guid.NewGuid())
     {
         Name = name;
         Description = description;

--- a/section-05/start/src/DomeGym.Domain/SubscriptionAggregate/Subscription.cs
+++ b/section-05/start/src/DomeGym.Domain/SubscriptionAggregate/Subscription.cs
@@ -16,8 +16,7 @@ public class Subscription : AggregateRoot
     public Subscription(
         SubscriptionType subscriptionType,
         Guid adminId,
-        Guid? id = null)
-            : base(id ?? Guid.NewGuid())
+        Guid? id = null) : base(id ?? Guid.NewGuid())
     {
         SubscriptionType = subscriptionType;
         _maxGyms = GetMaxGyms();

--- a/section-05/start/src/DomeGym.Domain/TrainerAggregate/Trainer.cs
+++ b/section-05/start/src/DomeGym.Domain/TrainerAggregate/Trainer.cs
@@ -17,8 +17,7 @@ public class Trainer : AggregateRoot
     public Trainer(
         Guid userId,
         Schedule? schedule = null,
-        Guid? id = null)
-            : base(id ?? Guid.NewGuid())
+        Guid? id = null) : base(id ?? Guid.NewGuid())
     {
         UserId = userId;
         _schedule = schedule ?? Schedule.Empty();

--- a/section-06/start/src/DomeGym.Domain/AdminAggregate/Admin.cs
+++ b/section-06/start/src/DomeGym.Domain/AdminAggregate/Admin.cs
@@ -14,8 +14,7 @@ public class Admin : AggregateRoot
     public Admin(
         Guid userId,
         Guid? subscriptionId = null,
-        Guid? id = null)
-        : base(id ?? Guid.NewGuid())
+        Guid? id = null) : base(id ?? Guid.NewGuid())
     {
         UserId = userId;
         SubscriptionId = subscriptionId;

--- a/section-06/start/src/DomeGym.Domain/Common/Entities/Schedule.cs
+++ b/section-06/start/src/DomeGym.Domain/Common/Entities/Schedule.cs
@@ -10,8 +10,7 @@ public class Schedule : Entity
 
     public Schedule(
         Dictionary<DateOnly, List<TimeRange>>? calendar = null,
-        Guid? id = null)
-            : base(id ?? Guid.NewGuid())
+        Guid? id = null) : base(id ?? Guid.NewGuid())
     {
         _calendar = calendar ?? new();
     }

--- a/section-06/start/src/DomeGym.Domain/GymAggregate/Gym.cs
+++ b/section-06/start/src/DomeGym.Domain/GymAggregate/Gym.cs
@@ -23,8 +23,7 @@ public class Gym : AggregateRoot
         string name,
         int maxRooms,
         Guid subscriptionId,
-        Guid? id = null)
-            : base(id ?? Guid.NewGuid())
+        Guid? id = null) : base(id ?? Guid.NewGuid())
     {
         Name = name;
         _maxRooms = maxRooms;

--- a/section-06/start/src/DomeGym.Domain/SessionAggregate/Session.cs
+++ b/section-06/start/src/DomeGym.Domain/SessionAggregate/Session.cs
@@ -40,8 +40,7 @@ public class Session : AggregateRoot
         DateOnly date,
         TimeRange time,
         List<SessionCategory> categories,
-        Guid? id = null)
-            : base(id ?? Guid.NewGuid())
+        Guid? id = null) : base(id ?? Guid.NewGuid())
     {
         Name = name;
         Description = description;

--- a/section-06/start/src/DomeGym.Domain/SubscriptionAggregate/Subscription.cs
+++ b/section-06/start/src/DomeGym.Domain/SubscriptionAggregate/Subscription.cs
@@ -17,8 +17,7 @@ public class Subscription : AggregateRoot
     public Subscription(
         SubscriptionType subscriptionType,
         Guid adminId,
-        Guid? id = null)
-            : base(id ?? Guid.NewGuid())
+        Guid? id = null) : base(id ?? Guid.NewGuid())
     {
         SubscriptionType = subscriptionType;
         _maxGyms = GetMaxGyms();

--- a/section-06/start/src/DomeGym.Domain/TrainerAggregate/Trainer.cs
+++ b/section-06/start/src/DomeGym.Domain/TrainerAggregate/Trainer.cs
@@ -17,8 +17,7 @@ public class Trainer : AggregateRoot
     public Trainer(
         Guid userId,
         Schedule? schedule = null,
-        Guid? id = null)
-            : base(id ?? Guid.NewGuid())
+        Guid? id = null) : base(id ?? Guid.NewGuid())
     {
         UserId = userId;
         _schedule = schedule ?? Schedule.Empty();

--- a/section-10/end/GymManagement/src/GymManagement.Domain/AdminAggregate/Admin.cs
+++ b/section-10/end/GymManagement/src/GymManagement.Domain/AdminAggregate/Admin.cs
@@ -15,8 +15,7 @@ public class Admin : AggregateRoot
     public Admin(
         Guid userId,
         Guid? subscriptionId = null,
-        Guid? id = null)
-        : base(id ?? Guid.NewGuid())
+        Guid? id = null) : base(id ?? Guid.NewGuid())
     {
         UserId = userId;
         SubscriptionId = subscriptionId;

--- a/section-10/end/SessionReservation/src/SessionReservation.Domain/SessionAggregate/Session.cs
+++ b/section-10/end/SessionReservation/src/SessionReservation.Domain/SessionAggregate/Session.cs
@@ -40,8 +40,7 @@ public class Session : AggregateRoot
         DateOnly date,
         TimeRange time,
         List<SessionCategory> categories,
-        Guid? id = null)
-        : base(id ?? Guid.NewGuid())
+        Guid? id = null) : base(id ?? Guid.NewGuid())
     {
         Name = name;
         Description = description;

--- a/section-10/end/UserManagement/src/UserManagement.Domain/UserAggregate/User.cs
+++ b/section-10/end/UserManagement/src/UserManagement.Domain/UserAggregate/User.cs
@@ -25,8 +25,7 @@ public class User : AggregateRoot
         Guid? adminId = null,
         Guid? participantId = null,
         Guid? trainerId = null,
-        Guid? id = null)
-            : base(id ?? Guid.NewGuid())
+        Guid? id = null) : base(id ?? Guid.NewGuid())
     {
         FirstName = firstName;
         LastName = lastName;


### PR DESCRIPTION
Ex.
## Before
- Case 1.
```cs
public Schedule(
        Dictionary<DateOnly, List<TimeRange>>? calendar = null,
        Guid? id = null) 
             : base(id ?? Guid.NewGuid())
```

- Case 2.
```cs
public Schedule(
        Dictionary<DateOnly, List<TimeRange>>? calendar = null,
        Guid? id = null) 
        : base(id ?? Guid.NewGuid())
```

## After
```cs
public Schedule(
        Dictionary<DateOnly, List<TimeRange>>? calendar = null,
        Guid? id = null) : base(id ?? Guid.NewGuid())
 ```