### PR TITLE
Fix error type

### DIFF
--- a/section-05/end/src/DomeGym.Domain/ParticipantAggregate/Participant.cs
+++ b/section-05/end/src/DomeGym.Domain/ParticipantAggregate/Participant.cs
@@ -56,7 +56,7 @@ public class Participant : AggregateRoot
     {
         if (!_sessionIds.Contains(session.Id))
         {
-            return Error.NotFound(description: "Session not found");
+            return Error.NotFound(description: "Session not found in participant's schedule");
         }
 
         var removeBookingResult = _schedule.RemoveBooking(

--- a/section-05/end/src/DomeGym.Domain/TrainerAggregate/Trainer.cs
+++ b/section-05/end/src/DomeGym.Domain/TrainerAggregate/Trainer.cs
@@ -50,7 +50,7 @@ public class Trainer : AggregateRoot
     {
         if (!_sessionIds.Contains(session.Id))
         {
-            return Error.Conflict("Trainer already assigned to teach session");
+            return Error.NotFound(description: "Session not found in trainer's schedule");
         }
 
         var removeBookingResult = _schedule.RemoveBooking(

--- a/section-05/start/src/DomeGym.Domain/ParticipantAggregate/Participant.cs
+++ b/section-05/start/src/DomeGym.Domain/ParticipantAggregate/Participant.cs
@@ -56,7 +56,7 @@ public class Participant : AggregateRoot
     {
         if (!_sessionIds.Contains(session.Id))
         {
-            return Error.NotFound(description: "Session not found");
+            return Error.NotFound(description: "Session not found in participant's schedule");
         }
 
         var removeBookingResult = _schedule.RemoveBooking(

--- a/section-05/start/src/DomeGym.Domain/TrainerAggregate/Trainer.cs
+++ b/section-05/start/src/DomeGym.Domain/TrainerAggregate/Trainer.cs
@@ -50,7 +50,7 @@ public class Trainer : AggregateRoot
     {
         if (!_sessionIds.Contains(session.Id))
         {
-            return Error.Conflict("Trainer already assigned to teach session");
+            return Error.NotFound(description: "Session not found in trainer's schedule");
         }
 
         var removeBookingResult = _schedule.RemoveBooking(

--- a/section-06/start/src/DomeGym.Domain/TrainerAggregate/Trainer.cs
+++ b/section-06/start/src/DomeGym.Domain/TrainerAggregate/Trainer.cs
@@ -50,7 +50,7 @@ public class Trainer : AggregateRoot
     {
         if (!_sessionIds.Contains(session.Id))
         {
-            return Error.NotFound("Session not found in trainer's schedule");
+            return Error.NotFound(description: "Session not found in trainer's schedule");
         }
 
         var removeBookingResult = _schedule.RemoveBooking(

--- a/section-10/end/SessionReservation/src/SessionReservation.Domain/TrainerAggregate/Trainer.cs
+++ b/section-10/end/SessionReservation/src/SessionReservation.Domain/TrainerAggregate/Trainer.cs
@@ -52,7 +52,7 @@ public class Trainer : AggregateRoot
     {
         if (!_sessionIds.Contains(session.Id))
         {
-            return Error.NotFound("Session not found in trainer's schedule");
+            return Error.NotFound(description: "Session not found in trainer's schedule");
         }
 
         var removeBookingResult = _schedule.RemoveBooking(


### PR DESCRIPTION
Ex.

## Before
```cs
return Error.Conflict("Trainer already assigned to teach session");
```

## After
```cs
return Error.NotFound(description: "Session not found in trainer's schedule");
```