### PR TITLE
Fix local varaible name

### DIFF
--- a/section-05/end/src/DomeGym.Application/Rooms/Commands/CreateRoom/CreateRoomCommandHandler.cs
+++ b/section-05/end/src/DomeGym.Application/Rooms/Commands/CreateRoom/CreateRoomCommandHandler.cs
@@ -39,11 +39,11 @@ public class CreateRoomCommandHandler : IRequestHandler<CreateRoomCommand, Error
             maxDailySessions: subscription.GetMaxDailySessions(),
             gymId: gym.Id);
 
-        var addGymResult = gym.AddRoom(room);
+        var addRoomResult = gym.AddRoom(room);
 
-        if (addGymResult.IsError)
+        if (addRoomResult.IsError)
         {
-            return addGymResult.Errors;
+            return addRoomResult.Errors;
         }
 
         await _gymsRepository.UpdateAsync(gym);

--- a/section-05/start/src/DomeGym.Application/Rooms/Commands/CreateRoom/CreateRoomCommandHandler.cs
+++ b/section-05/start/src/DomeGym.Application/Rooms/Commands/CreateRoom/CreateRoomCommandHandler.cs
@@ -39,11 +39,11 @@ public class CreateRoomCommandHandler : IRequestHandler<CreateRoomCommand, Error
             maxDailySessions: subscription.GetMaxDailySessions(),
             gymId: gym.Id);
 
-        var addGymResult = gym.AddRoom(room);
+        var addRoomResult = gym.AddRoom(room);
 
-        if (addGymResult.IsError)
+        if (addRoomResult.IsError)
         {
-            return addGymResult.Errors;
+            return addRoomResult.Errors;
         }
 
         await _gymsRepository.UpdateAsync(gym);

--- a/section-06/start/src/DomeGym.Application/Rooms/Commands/CreateRoom/CreateRoomCommandHandler.cs
+++ b/section-06/start/src/DomeGym.Application/Rooms/Commands/CreateRoom/CreateRoomCommandHandler.cs
@@ -39,11 +39,11 @@ public class CreateRoomCommandHandler : IRequestHandler<CreateRoomCommand, Error
             maxDailySessions: subscription.GetMaxDailySessions(),
             gymId: gym.Id);
 
-        var addGymResult = gym.AddRoom(room);
+        var addRoomResult = gym.AddRoom(room);
 
-        if (addGymResult.IsError)
+        if (addRoomResult.IsError)
         {
-            return addGymResult.Errors;
+            return addRoomResult.Errors;
         }
 
         await _gymsRepository.UpdateAsync(gym);

--- a/section-10/end/GymManagement/src/GymManagement.Application/Rooms/Commands/CreateRoom/CreateRoomCommandHandler.cs
+++ b/section-10/end/GymManagement/src/GymManagement.Application/Rooms/Commands/CreateRoom/CreateRoomCommandHandler.cs
@@ -39,11 +39,11 @@ public class CreateRoomCommandHandler : IRequestHandler<CreateRoomCommand, Error
             gymId: gym.Id,
             maxDailySessions: subscription.GetMaxDailySessions());
 
-        var addGymResult = gym.AddRoom(room);
+        var addRoomResult = gym.AddRoom(room);
 
-        if (addGymResult.IsError)
+        if (addRoomResult.IsError)
         {
-            return addGymResult.Errors;
+            return addRoomResult.Errors;
         }
 
         await _gymsRepository.UpdateAsync(gym);


### PR DESCRIPTION
Ex.

## Before
```cs
var addGymResult = gym.AddRoom(room);
```

## After
```cs
var addRoomResult = gym.AddRoom(room);
```