### PR TITLE
fix error type in ReservationCanceledEventHandler

### DIFF
--- a/section-06/start/src/DomeGym.Application/Participants/Events/ReservationCanceledEventHandler.cs
+++ b/section-06/start/src/DomeGym.Application/Participants/Events/ReservationCanceledEventHandler.cs
@@ -25,7 +25,7 @@ public class ReservationCanceledEventHandler : INotificationHandler<ReservationC
         if (removeBookingResult.IsError)
         {
             throw new EventualConsistencyException(
-                ReservationCanceledEvent.ParticipantNotFound,
+                ReservationCanceledEvent.ParticipantScheduleUpdateFailed,
                 removeBookingResult.Errors);
         }
 

--- a/section-10/end/SessionReservation/src/SessionReservation.Application/Participants/Events/ReservationCanceledEventHandler.cs
+++ b/section-10/end/SessionReservation/src/SessionReservation.Application/Participants/Events/ReservationCanceledEventHandler.cs
@@ -26,7 +26,7 @@ public class ReservationCanceledEventHandler : INotificationHandler<ReservationC
         if (removeBookingResult.IsError)
         {
             throw new EventualConsistencyException(
-                ReservationCanceledEvent.ParticipantNotFound,
+                ReservationCanceledEvent.ParticipantScheduleUpdateFailed,
                 removeBookingResult.Errors);
         }
 


### PR DESCRIPTION
Ex.

## Before
```cs
var removeBookingResult = participant.RemoveFromSchedule(notification.Session);
if (removeBookingResult.IsError)
{
    throw new EventualConsistencyException(
        ReservationCanceledEvent.ParticipantNotFound
```

## After
```cs
var removeBookingResult = participant.RemoveFromSchedule(notification.Session);
if (removeBookingResult.IsError)
{
    throw new EventualConsistencyException(
        ReservationCanceledEvent.ParticipantScheduleUpdateFailed           // <-
```